### PR TITLE
example-runtime-bundle to 7.0.38

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -22,3 +22,6 @@ dependencies:
 - name: activiti-cloud-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.51
+- name: example-runtime-bundle
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 7.0.38


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.38