### PR TITLE
example-runtime-bundle to 7.0.40

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,4 +24,4 @@ dependencies:
   version: 1.0.51
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.38
+  version: 7.0.40


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.40